### PR TITLE
Add comments to explain why we fix certain UIDs and GIDs

### DIFF
--- a/src/aws.yml
+++ b/src/aws.yml
@@ -6,6 +6,9 @@
   roles:
     - role: amazon_efs_utils
       vars:
+        # Note that we use the same GID for the efs_users group on all
+        # instances.  This helps us avoid UID/GID collisions with
+        # files written to the EFS share.
         efs_users_gid: 2048
     - amazon_ssm_agent
     # This is for the python3-botocore task below

--- a/src/samba.yml
+++ b/src/samba.yml
@@ -7,8 +7,14 @@
     - role: samba
       vars:
         create_guest_user: yes
+        # Note that we use the same UID for the VNC and Samba guest
+        # users on all instances.  This helos us avoid UID/GID
+        # collisions with files written to the EFS share.
         guest_user_uid: 2048
         guest_user_groups:
+          # Note that this means that the aws.yml playbook _must_ run
+          # before this one, so that the efs_users group has been
+          # created.
           - efs_users
         server: yes
   tasks:

--- a/src/samba.yml
+++ b/src/samba.yml
@@ -8,7 +8,7 @@
       vars:
         create_guest_user: yes
         # Note that we use the same UID for the VNC and Samba guest
-        # users on all instances.  This helos us avoid UID/GID
+        # users on all instances.  This helps us avoid UID/GID
         # collisions with files written to the EFS share.
         guest_user_uid: 2048
         guest_user_groups:


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a few comments to explain why we fix certain UIDs and GIDs.

## 💭 Motivation and context ##

This is all done to avoid UID/GID collisions with files written to the EFS share.

## 🧪 Testing ##

Given that the changes are purely in documentation, there is nothing to really test with this pull request.  Please see cisagov/kali-packer#79 to see how the UID/GID values set here interface with other AMIs.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
